### PR TITLE
Add Country resource endpoints

### DIFF
--- a/.github/README.md
+++ b/.github/README.md
@@ -14,7 +14,66 @@
 
 ## API
 
-TODO: Complete API documentation
+### Authorization
+
+#### `POST /api/auth/login`
+
+Allows a user to login.
+
+Takes an object containing valid `username` and `password` properties, and returns a JSON Web Token to the client. This token must be included in the `authorization` request header to access any other routes.
+
+#### `POST /api/auth/register`
+
+Allows an Admin user to create new users, will return 401 to clients attempting to access the resource with no credentials and 403 to clients attempting to access the resource with insufficient credentials.
+
+Takes an object containing:
+
+1. A unique `username` (**String**)
+2. A `password` (**String**)
+3. A `role_id` (**Integer**) [Admin=1, User=2]
+4. A `country_id` (**Integer**) [Default=Null, Integer corresponds to the specific country a user should have access to]
+
+If a `country_id` is not specified, will default to `null`.
+
+### Countries
+
+#### `GET /api/countries`
+
+Returns a array of objects listing all known countries to an authenticated client.
+
+```json
+[
+  {
+      "Code": "AF",
+      "Country": "Afghanistan"
+  },
+  {
+      "Code": "AX",
+      "Country": "Åland Islands"
+  },
+  {
+      "Code": "AL",
+      "Country": "Albania"
+  },
+  {
+      "Code": "DZ",
+      "Country": "Algeria"
+  },
+]
+```
+
+#### `GET /api/countries/active`
+
+Returns a list of active countries, defined as a country that has at least one community in our database.
+
+If user is not an Admin, it will return only the country specified in the token provided by the client.
+
+```json
+{
+    "Communities": "5",
+    "Country": "United States"
+}
+```
 
 ## Maintainer
 

--- a/controllers/country.js
+++ b/controllers/country.js
@@ -1,0 +1,36 @@
+const router = require('express').Router()
+const Country = require('../models/db/countries');
+
+router.get('/', async (req, res) => {
+  try {
+    const countries = await Country.get();
+    return res.status(200).json(countries)
+  }
+  catch (e) {
+    console.log(e);
+    return res.status(500).json({
+      message: "Sorry about that! We encountered an issue getting the list of countries for you"
+    })
+  }
+})
+
+router.get('/active', async (req, res) => {
+  const countryCode = req.accessCountry
+  try {
+    const countries = await Country.getActive(countryCode);
+    if (!countries) {
+      return res.status(404).json({
+        message: "It appears that there are currently no active countries"
+      })
+    }
+    return res.status(200).json(countries)
+  }
+  catch (e) {
+    console.log(e)
+    return res.status(500).json({
+      message: "Sorry! We encountered an error getting the list of active countries"
+    })
+  }
+})
+
+module.exports = router;

--- a/index.js
+++ b/index.js
@@ -4,8 +4,10 @@ const bodyParser = require("body-parser");
 const cors = require("cors");
 const morgan = require("morgan");
 const helmet = require("helmet");
+const { checkToken } =  require('./middlewares/authorization');
 
 const authRoutes = require('./controllers/auth');
+const countryRoutes = require('./controllers/country');
 
 const app = express();
 
@@ -17,7 +19,8 @@ app.use(helmet());
 app.use(morgan("dev"));
 
 // Routes:
-app.use('/api/auth/', authRoutes);
+app.use('/api/auth', authRoutes);
+app.use('/api/countries', checkToken, countryRoutes)
 
 app.get("/", (req, res) => {
   res.status(200).json({ message: "Server is up" });

--- a/middlewares/authorization.js
+++ b/middlewares/authorization.js
@@ -9,6 +9,7 @@ exports.checkToken = (req, res, next) => {
         res.status(401).json({ message: "Invalid Credentials" });
       } else {
         req.decodedJwt = decodedToken;
+        req.accessCountry = decodedToken.country_code
         next();
       }
     });

--- a/models/db/countries.js
+++ b/models/db/countries.js
@@ -1,19 +1,29 @@
 const db = require("../index");
 
 const get = () => {
-  return db("countries AS cn").select('cn.name AS Country', 'cn.code AS Code');
+  return db("countries AS cn").select("cn.name AS Country", "cn.code AS Code");
 };
 
-const getActive = () => {
-  return db('countries AS cn')
-    .select('cn.name AS Country')
-    .count('cm.id AS Communities')
-    .join('communities AS cm', {'cm.country_id': 'cn.id'})
-    .groupBy('cn.name')
-    .orderBy('communities')
-}
+const getActive = countryCode => {
+  if (countryCode) {
+    return db("countries AS cn")
+      .select("cn.name AS Country")
+      .count("cm.id AS Communities")
+      .join("communities AS cm", { "cm.country_id": "cn.id" })
+      .groupBy("cn.name")
+      .orderBy("Communities")
+      .where({ "cn.code": countryCode })
+      .first();
+  }
+  return db("countries AS cn")
+    .select("cn.name AS Country")
+    .count("cm.id AS Communities")
+    .join("communities AS cm", { "cm.country_id": "cn.id" })
+    .groupBy("cn.name")
+    .orderBy("Communities");
+};
 
 module.exports = {
   get,
   getActive
-}
+};

--- a/models/db/countries.js
+++ b/models/db/countries.js
@@ -1,0 +1,19 @@
+const db = require("../index");
+
+const get = () => {
+  return db("countries AS cn").select('cn.name AS Country', 'cn.code AS Code');
+};
+
+const getActive = () => {
+  return db('countries AS cn')
+    .select('cn.name AS Country')
+    .count('cm.id AS Communities')
+    .join('communities AS cm', {'cm.country_id': 'cn.id'})
+    .groupBy('cn.name')
+    .orderBy('communities')
+}
+
+module.exports = {
+  get,
+  getActive
+}


### PR DESCRIPTION
This PR, when merged, will make the `/api/country/` resource available, along with all of its sub-routes

## TODO:
- [x] build the `get()` db method to allow for getting a list of all countries
- [x] build the `getActive()` db method to allow for getting only countries that have active communities
- [x] enable GET requests to `/api/countries/`
- [x] enable GET requests to `/api/countries/active`

I was initially going to say that if you specified a particular country in a call to the get resource you'd get it back with a list of communities, but I think that's actually going to be better served on the `/api/communities/` resource